### PR TITLE
Chore: add TypeScript shims

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@not-an-aardvark/node-release-script": "^0.1.0",
+    "@types/eslint": "^4.16.6",
     "eslint": "^5.13.0",
     "eslint-config-eslint": "^5.0.1",
     "eslint-plugin-eslint-plugin": "^2.0.1",

--- a/shims.d.ts
+++ b/shims.d.ts
@@ -1,0 +1,30 @@
+declare module 'eslint-rule-composer' {
+    import * as estree from 'estree'
+    import * as eslint from 'eslint'
+
+    interface Problem {
+        node: estree.Node | null
+        message: string
+        messageId: string | null
+        data: object | null
+        loc: eslint.AST.SourceLocation
+        fix?: (fixer: eslint.Rule.RuleFixer) => (eslint.Rule.Fix | null)
+    }
+
+    interface Metadata {
+        sourceCode: eslint.SourceCode
+        settings?: object
+        options: any[]
+        filename: string
+    }
+
+    interface Predicate<T> {
+        (problem: Problem, metadata: Metadata): T
+    }
+
+    export function mapReports(rule: eslint.Rule.RuleModule, predicate: Predicate<Problem>): eslint.Rule.RuleModule
+
+    export function filterReports(rule: eslint.Rule.RuleModule, predicate: Predicate<boolean>): eslint.Rule.RuleModule
+
+    export function joinReports(rules: eslint.Rule.RuleModule[]): eslint.Rule.RuleModule
+}


### PR DESCRIPTION
如果在使用 VS Code 的时候无法进行自动补全，需要保持 `shims.d.ts` 文件处于打开状态（以便让 TypeScript 将这个文件读入内存并分析，我不确定是我的做法有误还是 VS Code 或 TypeScript 问题）。