### PR TITLE
New: add fixer for rule "no-eq-null"

### DIFF
--- a/lib/rules/no-eq-null.js
+++ b/lib/rules/no-eq-null.js
@@ -1,0 +1,26 @@
+/**
+ * @fileoverview Add fixer to rule no-eq-null.
+ * @author Pig Fang <g-plane@hotmail.com>
+ */
+"use strict";
+
+const ruleComposer = require("eslint-rule-composer");
+const utils = require("../utils");
+
+const rule = utils.getFixableRule("no-eq-null", false);
+
+module.exports = ruleComposer.mapReports(
+    rule,
+    (problem, { sourceCode }) => {
+        problem.fix = fixer => {
+            const { node } = problem;
+
+            const token = node.right.type === "Literal" && node.right.raw === "null"
+                ? sourceCode.getTokenBefore(node.right)
+                : sourceCode.getTokenAfter(node.left);
+
+            return fixer.insertTextAfter(token, "=");
+        };
+        return problem;
+    }
+);

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,7 @@ Name | ✔️ | 🛠 | Description
 [no-alert](https://eslint.org/docs/rules/no-alert) |  | 🛠 | disallow the use of `alert`, `confirm`, and `prompt`
 [no-console](https://eslint.org/docs/rules/no-console) | ✔️ | 🛠 | disallow the use of `console`
 [no-debugger](https://eslint.org/docs/rules/no-debugger) | ✔️ | 🛠 | disallow the use of `debugger`
+[no-eq-null](https://eslint.org/docs/rules/no-eq-null) |  | 🛠 | disallow `null` comparisons without type-checking operators
 [no-new-symbol](https://eslint.org/docs/rules/no-new-symbol) |  | 🛠 | disallow `new` operators with the `Symbol` object
 [no-plusplus](https://eslint.org/docs/rules/no-plusplus) | ✔️ | 🛠 | disallow the unary operators `++` and `--`
 [no-prototype-builtins](https://eslint.org/docs/rules/no-prototype-builtins) |  | 🛠 | disallow calling some `Object.prototype` methods directly on objects

--- a/tests/lib/rules/no-eq-null.js
+++ b/tests/lib/rules/no-eq-null.js
@@ -1,0 +1,48 @@
+/**
+ * @fileoverview Tests for rule no-eq-null.
+ * @author Pig Fang <g-plane@hotmail.com>
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/no-eq-null");
+const RuleTester = require("eslint").RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+const errors = [{ messageId: "unexpected", type: "BinaryExpression" }];
+
+ruleTester.run("no-eq-null", rule, {
+    valid: [
+        "a === null",
+        "a !== null"
+    ],
+    invalid: [
+        {
+            code: "a == null",
+            output: "a === null",
+            errors
+        },
+        {
+            code: "a != null",
+            output: "a !== null",
+            errors
+        },
+        {
+            code: "null == a",
+            output: "null === a",
+            errors
+        },
+        {
+            code: "null != a",
+            output: "null !== a",
+            errors
+        }
+    ]
+});


### PR DESCRIPTION
ESLint 的建议是 `Use '===' to compare with null.`，所以我感觉问题不大，而且这个是 unsafe 的。